### PR TITLE
Provide a pyproject.toml file (fixes a build issue)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .tox
 __pycache__
 *.pyc
+.eggs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=61.0", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name        = "xapian-bindings"
+description = "Meta-package to build and install xapian-bindings extension."
+requires-python = ">=3.4"
+authors = [
+  { name="Chris Church", email="chris@ninemoremminutes.com" },
+]
+license = "BSD-3-Clause"  # TODO: check this, the setup.py merely specified "BSD" but text looks like BSD-3
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.4",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["xapian", "bindings", "haystack"]
+dynamic = ["version", "readme"]
+
+[project.urls]
+"Homepage" = "https://github.com/ninemoreminutes/xapian-bindings/"
+"Documentation" = "https://github.com/ninemoreminutes/xapian-bindings/"
+"Source" = "https://github.com/ninemoreminutes/xapian-bindings/"
+"Tracker" = "https://github.com/ninemoreminutes/xapian-bindings/issues"
+
+[tool.setuptools]
+py-modules = ["_custom_build"]
+
+[tool.setuptools.dynamic]
+version = {attr="xapian.bindings.__version__"}
+readme = {file = ["README.rst"], content-type = "text/x-rst"}
+
+# [tool.setuptools.cmdclass]
+# build_py = "_custom_build.build_py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ readme-renderer==29.0
     # via twine
 requests-toolbelt==0.9.1
     # via twine
-requests==2.25.1
+requests==2.32.5
     # via
     #   -r requirements.in
     #   requests-toolbelt


### PR DESCRIPTION
Hi,

recently this package started failing to install for me. After investigating the issue, this looks to be caused by `xapian-bindings` using `requests` during the install. Changes in the build system mean that `request` can no longer be used using the legacy `setup.py`based install, as some dependencies (in my case `urllib3`) will not always have been installed in time.

By providing a `pyproject.toml` file, `pip` will now properly install `requests` first. This PR provides the minimal amount of changes for this.

This should fix various installation problems related to requests by properly providing the build requirements. We are now using setup.cfg, setup.py, requirements.in, requirements.txt and pyproject.toml simultaneously, which is a bit of a mess. However, this was the least amount of changes needed to provide pyproject.toml .

**Important notes:**

-  You've specified the license to be ` BSD`, however that is no longer specific enough and is considered an invalid value by `pip`. I've found that the SPDX license name which matches your license text the closest is the BSD-3-Clause, but I am not sure. Please check if this is still the license you intended.
- I've bumped `requests` in the `requirement.txt` to fix an issue. You may want to bump other versions too.
- Tested only on x86_64.

It would be great if you could check this change and publish a new version to PyPI. Thanks.

With best regards,
IMayBeABitShy